### PR TITLE
a workaround to solve the schema version issue

### DIFF
--- a/extra_roles/workaround_pkg/tasks/main.yml
+++ b/extra_roles/workaround_pkg/tasks/main.yml
@@ -1,0 +1,15 @@
+# this task is a workaround to solve the schema version issue
+# 
+# pkg: Repo FreeBSD needs schema upgrade from 2013 to 2014 but it is opened readonly
+# pkg: need to re-create repo FreeBSD to upgrade schema version
+# pkg: Repository FreeBSD cannot be opened. 'pkg update' required
+# pkg: No packages available to install matching 'java/openjdk8' have been found in the repositories
+#
+# pkgng module does 'pkg install -U' and does not update the local repository
+# catalogue after upgrading the 'pkg' package.
+
+- name: upgrade pkg
+  command: pkg upgrade -y pkg
+  register: register_upgrade_pkg
+  changed_when: '"Number of packages to be upgraded" in register_upgrade_pkg.stdout'
+  when: ansible_os_family == "FreeBSD"

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -1,5 +1,6 @@
 - hosts: localhost
   roles:
+    - workaround_pkg
     - reallyenglish.java
     - reallyenglish.apt-repo
     - ansible-role-jenkins-master


### PR DESCRIPTION
pkg: Repo FreeBSD needs schema upgrade from 2013 to 2014 but it is opened readonly
pkg: need to re-create repo FreeBSD to upgrade schema version
pkg: Repository FreeBSD cannot be opened. 'pkg update' required
pkg: No packages available to install matching 'java/openjdk8' have been found in the repositories

pkgng module does 'pkg install -U' and does not update the local repository
catalogue after upgrading the 'pkg' package.