### PR TITLE
[bugfix] append to log file, not truncate it

### DIFF
--- a/files/jenkins.patch
+++ b/files/jenkins.patch
@@ -1,0 +1,11 @@
+--- /usr/local/etc/rc.d/jenkins.orig	2017-09-01 06:56:43.458062000 +0000
++++ /usr/local/etc/rc.d/jenkins	2017-09-01 07:01:40.474866000 +0000
+@@ -60,7 +60,7 @@
+ command="/usr/sbin/daemon"
+ java_cmd="${jenkins_java_home}/bin/java"
+ procname="${java_cmd}"
+-command_args="-p ${pidfile} ${java_cmd} -DJENKINS_HOME=${jenkins_home} ${jenkins_java_opts} -jar /usr/local/share/jenkins/jenkins.war ${jenkins_args} > ${jenkins_log_file} 2>&1"
++command_args="-p ${pidfile} ${java_cmd} -DJENKINS_HOME=${jenkins_home} ${jenkins_java_opts} -jar /usr/local/share/jenkins/jenkins.war ${jenkins_args} >> ${jenkins_log_file} 2>&1"
+ required_files="${java_cmd}"
+ 
+ start_precmd="jenkins_prestart"

--- a/tasks/install-FreeBSD.yml
+++ b/tasks/install-FreeBSD.yml
@@ -11,6 +11,11 @@
     state: present
   notify: Create admin users
 
+- name: Patch rc script jenkins.patch
+  patch:
+    src: jenkins.patch
+    dest: /usr/local/etc/rc.d/jenkins
+
 - name: Create rc.conf/jenkins
   template:
     src: FreeBSD/rc.jenkins.j2

--- a/tests/serverspec/default_spec.rb
+++ b/tests/serverspec/default_spec.rb
@@ -229,3 +229,14 @@ nodes.each do |node|
     its(:stderr) { should match(/^$/) }
   end
 end
+
+if os[:family] == "freebsd"
+  describe file("/usr/local/etc/rc.d/jenkins") do
+    its(:content) do
+      should match(/#{Regexp.escape(">> ${jenkins_log_file}")}/)
+    end
+    its(:content) do
+      should_not match(/[^>]#{Regexp.escape("> ${jenkins_log_file}")}/)
+    end
+  end
+end


### PR DESCRIPTION
this was fixed at https://github.com/freebsd/freebsd-ports/commit/61e5cbc42286f9f6a444381783c99ae1b122562f.

the patch is for jenkins package < 2.46, which fixes

* log file is truncated when jenkins is restarted
* null characters are filled at the beginning of the log file when
  rotated